### PR TITLE
feat(app-component): ログイン中画面実装

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -11,15 +11,37 @@
     </form>
   </div>
   <div class="login">
+    <ng-container *ngIf="user$ | async as user; else loginArea">
+      <button mat-icon-button class="notify">
+        <mat-icon>notifications</mat-icon>
+      </button>
+      <button
+        class="user-image"
+        mat-icon-button
+        [matMenuTriggerFor]="menu"
+        [style.background-image]="'url(' + user.avatarURL + ')'"
+      ></button>
+
+      <mat-menu #menu="matMenu">
+        <button mat-menu-item (click)="logout()">
+          <mat-icon>login</mat-icon>
+          <span>ログアウト</span>
+        </button>
+        <button mat-menu-item>
+          <mat-icon>account_box</mat-icon>
+          <span>マイページ</span>
+        </button>
+        <button mat-menu-item>
+          <mat-icon>help</mat-icon>
+          <span>ヘルプ</span>
+        </button>
+      </mat-menu>
+    </ng-container>
     <ng-template #loginArea>
       <button (click)="openDialog()" class="login-button">
         ログイン
       </button>
     </ng-template>
-    <div *ngIf="user$ | async as user; else loginArea" class="logout">
-      <p class="login-user">{{ user.name }}でログイン中</p>
-      <button class="logout-button" (click)="logout()">ログアウト</button>
-    </div>
   </div>
 </header>
 <router-outlet></router-outlet>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -7,6 +7,7 @@ header {
   font-family: -apple-system, system-ui, 'Segoe UI', Roboto, 'Helvetica Neue',
     Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
   font-weight: bold;
+  position: relative;
 }
 .header-left {
   display: flex;
@@ -132,26 +133,21 @@ footer {
 .login-button:hover {
   background-position: right center;
 }
-.logout-button {
-  font-family: 'Yu Gothic', YuGothic, Verdana, 'Hiragino Kaku Gothic ProN',
-    'Hiragino Kaku Gothic Pro', 'ヒラギノ角ゴ Pro W3', 'メイリオ', Meiryo,
-    sans-serif;
-  text-align: center;
-  padding-top: 20px;
-  display: block;
-  width: 100px;
-  text-align: center;
-  font-size: 10px;
-  color: #fff;
-  font-weight: bold;
-  padding: 12px 24px;
-  border-radius: 4px;
-  background-image: linear-gradient(-90deg, #ff006e, #ffd500);
-  border: none;
-  transition: 0.5s;
-  background-size: 200%;
-  margin-top: 20px;
+.login-user {
+  cursor: pointer;
+  padding-top: 16px;
 }
-.logout-button:hover {
-  background-position: right center;
+.user-image {
+  margin-top: 24px;
+  right: 12px;
+  top: -2px;
+}
+.notify {
+  position: absolute;
+  right: 128px;
+  top: 22px;
+  margin-right: 24px;
+  .mat-icon {
+    font-size: 38px;
+  }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -12,10 +12,6 @@ import { User } from './interfaces/user';
 })
 export class AppComponent {
   user$ = this.authService.afUser$;
-  @ViewChild(MatMenuTrigger) trigger: MatMenuTrigger;
-  someMethod() {
-    this.trigger.openMenu();
-  }
 
   constructor(
     private authService: AuthService,

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,7 +1,9 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { AuthService } from './services/auth.service';
 import { MatDialog } from '@angular/material/dialog';
 import { LoginDialogComponent } from './login-dialog/login-dialog.component';
+import { MatMenuModule, MatMenuTrigger } from '@angular/material/menu';
+import { User } from './interfaces/user';
 
 @Component({
   selector: 'app-root',
@@ -10,8 +12,16 @@ import { LoginDialogComponent } from './login-dialog/login-dialog.component';
 })
 export class AppComponent {
   user$ = this.authService.afUser$;
+  @ViewChild(MatMenuTrigger) trigger: MatMenuTrigger;
+  someMethod() {
+    this.trigger.openMenu();
+  }
 
-  constructor(private authService: AuthService, private dialog: MatDialog) {}
+  constructor(
+    private authService: AuthService,
+    private dialog: MatDialog,
+    private matMenu: MatMenuModule
+  ) {}
 
   openDialog() {
     this.dialog.open(LoginDialogComponent);

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -20,6 +20,8 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatInputModule } from '@angular/material/input';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { NotFoundComponent } from './not-found/not-found.component';
+import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatListModule } from '@angular/material/list';
 
 @NgModule({
   declarations: [AppComponent, LoginDialogComponent, NotFoundComponent],
@@ -41,6 +43,8 @@ import { NotFoundComponent } from './not-found/not-found.component';
     ReactiveFormsModule,
     MatInputModule,
     MatFormFieldModule,
+    MatSidenavModule,
+    MatListModule,
   ],
   providers: [{ provide: REGION, useValue: 'asia^northeast1' }],
   bootstrap: [AppComponent],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -22,6 +22,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { NotFoundComponent } from './not-found/not-found.component';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatListModule } from '@angular/material/list';
+import { MatMenuModule } from '@angular/material/menu';
 
 @NgModule({
   declarations: [AppComponent, LoginDialogComponent, NotFoundComponent],
@@ -45,6 +46,7 @@ import { MatListModule } from '@angular/material/list';
     MatFormFieldModule,
     MatSidenavModule,
     MatListModule,
+    MatMenuModule,
   ],
   providers: [{ provide: REGION, useValue: 'asia^northeast1' }],
   bootstrap: [AppComponent],


### PR DESCRIPTION
#72 

ログイン中の画面を実装しました。
御確認お願いします。

#やった事

- [ ] ログイン中のavartar追加
- [ ] notifications追加
- [ ] mat-menu-item　追加

<img width="186" alt="スクリーンショット 0032-08-02 午前9 48 56" src="https://user-images.githubusercontent.com/64081459/89112988-eaab2b00-d4a5-11ea-9c50-cc0d4cb925ce.png">
<img width="284" alt="スクリーンショット 0032-08-02 午前9 49 04" src="https://user-images.githubusercontent.com/64081459/89112991-eda61b80-d4a5-11ea-8f3c-b7789088da63.png">

